### PR TITLE
[feature/dashboard-refactor] 대시보드 수정 페이지 관련 버튼 클릭 시 재차 확인 기능 추가 

### DIFF
--- a/src/app/(protected)/dashboard/[id]/edit/page.tsx
+++ b/src/app/(protected)/dashboard/[id]/edit/page.tsx
@@ -123,9 +123,12 @@ export default function DashboardIdEdit() {
 
   // 대시보드 삭제 함수
   const handleDeleteDashboard = async () => {
+    const confirmDelete = window.confirm("이 대시보드를 삭제하시겠습니까?");
+    if (!confirmDelete) return;
+
     try {
       await deleteDashboard(dashboardId);
-      alert("대시보드가 삭제되었습니다!");
+      alert("대시보드가 정상적으로 삭제되었습니다!");
       router.push("/mydashboard");
     } catch (e) {
       console.error("대시보드 삭제 실패", e);
@@ -335,7 +338,7 @@ export default function DashboardIdEdit() {
         <MyButton
           onClick={handleDeleteDashboard}
           color="buttonBasic"
-          className="tablet:text-lg pc:mb-[33px] tablet:mb-12 tablet:w-80 tablet:h-[62px] text-brand-gray-700 mt-2 mb-25 h-13 w-full text-base font-medium"
+          className="tablet:text-lg pc:mb-[33px] tablet:mb-12 tablet:w-80 tablet:h-[62px] text-brand-gray-700 mt-2 mb-25 h-13 w-full bg-white text-base font-medium"
         >
           대시보드 삭제하기
         </MyButton>

--- a/src/app/(protected)/dashboard/[id]/edit/page.tsx
+++ b/src/app/(protected)/dashboard/[id]/edit/page.tsx
@@ -32,6 +32,7 @@ export default function DashboardIdEdit() {
   const colors = ["#7AC555", "#760DDE", "#FFA500", "#E876EA", "#76A5EA"];
 
   const [dashboardName, setDashboardName] = useState("");
+  const [displayName, setDisplayName] = useState("");
   const [selectedColor, setSelectedColor] = useState("#7AC555");
 
   const [members, setMembers] = useState<
@@ -58,6 +59,7 @@ export default function DashboardIdEdit() {
       try {
         const data = await getDashboardById(dashboardId);
         setDashboardName(data.title);
+        setDisplayName(data.title);
         setSelectedColor(data.color);
       } catch (e) {
         console.error("대시보드 조회 실패", e);
@@ -103,18 +105,17 @@ export default function DashboardIdEdit() {
 
   // 대시보드 수정 함수
   const handleUpdateDashboard = async () => {
+    const confirmUpdate = window.confirm("대시보드 이름을 변경하시겠습니까?");
+    if (!confirmUpdate) return;
+
     try {
       await updateDashboard(dashboardId, {
         title: dashboardName,
         color: selectedColor,
       });
 
+      setDisplayName(dashboardName);
       alert("대시보드가 성공적으로 수정되었습니다.");
-
-      queryClient.invalidateQueries({ queryKey: ["dashboards"] });
-      queryClient.invalidateQueries({ queryKey: ["dashboard", dashboardId] });
-
-      router.refresh();
     } catch (e) {
       console.error("대시보드 수정 실패", e);
       alert("대시보드 수정에 실패했습니다.");
@@ -128,7 +129,7 @@ export default function DashboardIdEdit() {
 
     try {
       await deleteDashboard(dashboardId);
-      alert("대시보드가 정상적으로 삭제되었습니다!");
+      alert("대시보드가 성공적으로 삭제되었습니다!");
       router.push("/mydashboard");
     } catch (e) {
       console.error("대시보드 삭제 실패", e);
@@ -183,7 +184,7 @@ export default function DashboardIdEdit() {
 
         {/* 대시보드 이름 + 색상 */}
         <section className="tablet:px-7 tablet:py-8 rounded-lg bg-white px-4 py-5 shadow-sm">
-          <h2 className="tablet:text-2xl mb-6 text-xl font-bold">비브리지</h2>
+          <h2 className="tablet:text-2xl mb-6 text-xl font-bold">{displayName}</h2>
           <div className="flex flex-col gap-4">
             <div>
               <Label className="tablet:text-2lg text-lg font-medium">대시보드 이름</Label>

--- a/src/app/(protected)/dashboard/[id]/page.tsx
+++ b/src/app/(protected)/dashboard/[id]/page.tsx
@@ -84,7 +84,7 @@ export default function DashboardId() {
       ))}
 
       {/* 새로운 컬럼 추가 버튼 */}
-      <div className="pc:pt-17 pc:w-[354px] mx-5 flex flex-shrink-0 py-5">
+      <div className="pc:pt-[38px] pc:w-[354px] flex flex-shrink-0 px-5 py-5">
         <MyButton
           onClick={handleAddColumn}
           className="border-brand-gray-300 dark:bg-dark-700 flex h-[70px] w-full items-center justify-center border bg-white"

--- a/src/components/mydashboard/MyDashboardList.tsx
+++ b/src/components/mydashboard/MyDashboardList.tsx
@@ -196,7 +196,7 @@ export default function MyDashboardList() {
         <div className="tablet:grid-cols-2 pc:grid-cols-3 grid min-h-[156px] grid-cols-1 gap-4">
           {/* 새 대시보드 버튼 */}
           <MyButton
-            className="h-[70px] p-4 text-center font-semibold"
+            className="h-[70px] bg-white p-4 text-center font-semibold"
             color="buttonBasic"
             onClick={() => setIsModalOpen(true)}
           >
@@ -206,7 +206,7 @@ export default function MyDashboardList() {
           {currentItems.map((dashboard, index) => (
             <MyButton
               key={`${dashboard.id}-${index}`}
-              className="pc:text-lg tablet:text-lg h-[70px] p-4 text-left text-sm font-semibold"
+              className="pc:text-lg tablet:text-lg h-[70px] bg-white p-4 text-left text-sm font-semibold"
               color="buttonBasic"
               onClick={() => router.push(`/dashboard/${dashboard.id}`)}
             >


### PR DESCRIPTION
## 🔥작업 내용
 * 대시보드 수정 페이지의 대시보드 이름 변경, 대시보드 삭제 버튼 클릭 시 재차 확인할 수 있는 alert 설정 하였습니다.
 * 대시보드 수정 페이지의 대시보드 삭제하기 버튼과 내 대시보드 리스트 배경색 복구 (bg-white)
 * 대시보드 상세 페이지의 새로운 컬럼 추가하기 버튼 위치 조정하였습니다. (멘토님 조언에 따라)

## 📸스크린샷 (선택사항)

